### PR TITLE
Corrected return types

### DIFF
--- a/DeviceHardware.h
+++ b/DeviceHardware.h
@@ -76,7 +76,7 @@ typedef enum {
 
 + (DeviceHardwareSpecificPlatform)specificPlatform;
 + (DeviceHardwareGeneralPlatform)generalPlatform;
-+ (DeviceHardwareGeneralPlatform)platformType;
++ (DeviceHardwarePlatformType)platformType;
 + (NSString *)platformString;
 
 + (NSString *)machine;

--- a/DeviceHardware.m
+++ b/DeviceHardware.m
@@ -91,10 +91,10 @@
 	if ([platform isEqualToString:DH_MACHINE_IPAD_3_4])      return DeviceHardwareGeneralPlatform_iPad_4;
 	if ([platform isEqualToString:DH_MACHINE_I386])          return DeviceHardwareGeneralPlatform_Simulator;
 	if ([platform isEqualToString:DH_MACHINE_X86_64])        return DeviceHardwareGeneralPlatform_Simulator;
-	return DeviceHardwareSpecificPlatform_Unknown;
+	return DeviceHardwareGeneralPlatform_Unknown;
 }
 
-+ (DeviceHardwareGeneralPlatform)platformType {
++ (DeviceHardwarePlatformType)platformType {
 	NSString *platform = [self machine];
 	if ([platform isEqualToString:DH_MACHINE_IPHONE_1_1])    return DeviceHardwarePlatformType_iPhone;
 	if ([platform isEqualToString:DH_MACHINE_IPHONE_1_2])    return DeviceHardwarePlatformType_iPhone;


### PR DESCRIPTION
1. platformType method return type was DeviceHardwareGeneralPlatform however it returns values of DeviceHardwarePlatformType. 
2. generalPlatform return value for unknown platform was DeviceHardwareSpecificPlatform_Unknown however this should be DeviceHardwareGeneralPlatform_Unknown.

Both issues are corrected.
